### PR TITLE
mf - Add GET endpoint for a single bike

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/BikeController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/BikeController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.example.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.ucsb.cs156.example.entities.Bike;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.BikeRepository;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -25,6 +26,16 @@ public class BikeController extends ApiController {
     @GetMapping("/all")
     public Iterable<Bike> allBikes() {
         return bikeRepository.findAll();
+    }
+
+    @ApiOperation(value = "Get a single bike")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Bike getById(
+            @ApiParam("id") @RequestParam Long id) {
+
+        return bikeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Bike.class, id));
     }
 
     @ApiOperation(value = "Create a new bike")

--- a/src/main/java/edu/ucsb/cs156/example/controllers/BikeController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/BikeController.java
@@ -1,0 +1,46 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.Bike;
+import edu.ucsb.cs156.example.repositories.BikeRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Api(description = "Bike")
+@RequestMapping("/api/bikes")
+@RestController
+@Slf4j
+public class BikeController extends ApiController {
+
+    @Autowired
+    BikeRepository bikeRepository;
+
+    @ApiOperation(value = "List all bikes")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Bike> allBikes() {
+        return bikeRepository.findAll();
+    }
+
+    @ApiOperation(value = "Create a new bike")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Bike postBike(
+            @ApiParam("manufacturer") @RequestParam String manufacturer,
+            @ApiParam("model") @RequestParam String model,
+            @ApiParam("number of gears") @RequestParam int numGears)
+            throws JsonProcessingException {
+
+        Bike bike = new Bike();
+        bike.setManufacturer(manufacturer);
+        bike.setModel(model);
+        bike.setNumGears(numGears);
+
+        return bikeRepository.save(bike);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/BikeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/BikeControllerTests.java
@@ -1,0 +1,130 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Bike;
+import edu.ucsb.cs156.example.repositories.BikeRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = BikeController.class)
+@Import(TestConfig.class)
+public class BikeControllerTests extends ControllerTestCase {
+
+        @MockBean
+        BikeRepository bikeRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/bikes/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/bikes/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/bikes/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        // Authorization tests for /api/bikes/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/bikes/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/bikes/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_bikes() throws Exception {
+
+                // arrange
+
+                Bike bike1 = Bike.builder()
+                        .model("Among Us")
+                        .manufacturer("Innersloth")
+                        .numGears(69)
+                        .id(0L)
+                        .build();
+
+                Bike bike2 = Bike.builder()
+                        .model("Deez nuts")
+                        .manufacturer("Vine Boom")
+                        .numGears(420)
+                        .id(1L)
+                        .build();
+
+                ArrayList<Bike> expectedBikes = new ArrayList<>(Arrays.asList(bike1, bike2));
+
+                when(bikeRepository.findAll()).thenReturn(expectedBikes);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/bikes/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(bikeRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedBikes);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_commons() throws Exception {
+                // arrange
+
+                Bike bike = Bike.builder()
+                        .model("Among Us")
+                        .manufacturer("Innersloth")
+                        .numGears(69)
+                        .id(0L)
+                        .build();
+
+                when(bikeRepository.save(eq(bike))).thenReturn(bike);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/bikes/post?model=Among Us&manufacturer=Innersloth&numGears=69&id=0")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(bikeRepository, times(1)).save(bike);
+                String expectedJson = mapper.writeValueAsString(bike);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+}


### PR DESCRIPTION
In this PR, we add the GET endpoint to get data of a single bike by ID and tests. 

I will need to rebase this once #55 is merged. Closes #34.