### PR TITLE
mf - Add PUT endpoint for Bikes

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/BikeController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/BikeController.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @Api(description = "Bike")
 @RequestMapping("/api/bikes")
 @RestController
@@ -53,5 +55,24 @@ public class BikeController extends ApiController {
         bike.setNumGears(numGears);
 
         return bikeRepository.save(bike);
+    }
+
+    @ApiOperation(value = "Update a single bike")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public Bike bike(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid Bike incoming) {
+
+        Bike bike = bikeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Bike.class, id));
+
+        bike.setManufacturer(incoming.getManufacturer());
+        bike.setModel(incoming.getModel());
+        bike.setNumGears(incoming.getNumGears());
+
+        bikeRepository.save(bike);
+
+        return bike;
     }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/BikeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/BikeControllerTests.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -181,4 +182,73 @@ public class BikeControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_bike() throws Exception {
+                // arrange
+                Bike bike = Bike.builder()
+                        .model("Among Us")
+                        .manufacturer("Innersloth")
+                        .numGears(69)
+                        .id(0L)
+                        .build();
+
+                Bike bikeEdited = Bike.builder()
+                        .model("Among Us 2: The More The Sussier")
+                        .manufacturer("Innersloth 2")
+                        .numGears(69^2)
+                        .id(0L)
+                        .build();
+
+                String requestBody = mapper.writeValueAsString(bikeEdited);
+
+                when(bikeRepository.findById(eq(0L))).thenReturn(Optional.of(bike));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/bikes?id=0")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .characterEncoding("utf-8")
+                                        .content(requestBody)
+                                        .with(csrf()))
+                        .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(bikeRepository, times(1)).findById(0L);
+                verify(bikeRepository, times(1)).save(bikeEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+                // arrange
+                Bike bikeEdited = Bike.builder()
+                        .model("Among Us 2: The More The Sussier")
+                        .manufacturer("Innersloth 2")
+                        .numGears(69^2)
+                        .id(0L)
+                        .build();
+
+                String requestBody = mapper.writeValueAsString(bikeEdited);
+
+                when(bikeRepository.findById(eq(0L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/bikes?id=0")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .characterEncoding("utf-8")
+                                        .content(requestBody)
+                                        .with(csrf()))
+                        .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(bikeRepository, times(1)).findById(0L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Bike with id 0 not found", json.get("message"));
+
+        }
+
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/BikeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/BikeControllerTests.java
@@ -222,7 +222,7 @@ public class BikeControllerTests extends ControllerTestCase {
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+        public void admin_cannot_edit_bike_that_does_not_exist() throws Exception {
                 // arrange
                 Bike bikeEdited = Bike.builder()
                         .model("Among Us 2: The More The Sussier")


### PR DESCRIPTION
In this PR, we add the PUT endpoint for Bike entities, allowing existing entries to be edited.

Closes #35 