### PR TITLE
mf: Add DELETE endpoint for Bikes

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/BikeController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/BikeController.java
@@ -75,4 +75,16 @@ public class BikeController extends ApiController {
 
         return bike;
     }
+
+    @ApiOperation(value = "Delete a Bike")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteBike(
+            @ApiParam("code") @RequestParam Long id) {
+        Bike bike = bikeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Bike.class, id));
+
+        bikeRepository.delete(bike);
+        return genericMessage("Bike with id %s deleted".formatted(id));
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/BikeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/BikeControllerTests.java
@@ -182,6 +182,54 @@ public class BikeControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_bike() throws Exception {
+                // arrange
+
+                Bike bike = Bike.builder()
+                        .model("Among Us")
+                        .manufacturer("Innersloth")
+                        .numGears(69)
+                        .id(0L)
+                        .build();
+
+                when(bikeRepository.findById(eq(0L))).thenReturn(Optional.of(bike));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/bikes?id=0")
+                                        .with(csrf()))
+                        .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(bikeRepository, times(1)).findById(0L);
+                verify(bikeRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Bike with id 0 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_bike_and_gets_right_error_message()
+                throws Exception {
+                // arrange
+
+                when(bikeRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/bikes?id=15")
+                                        .with(csrf()))
+                        .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(bikeRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Bike with id 15 not found", json.get("message"));
+        }
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void admin_can_edit_an_existing_bike() throws Exception {


### PR DESCRIPTION
In this PR, we add the DELETE endpoint and tests for Bikes. This allows a Bike to be deleted by id.

Closes #20 